### PR TITLE
Fix stage_ids variable name typo

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ def import_fund(
             assessments,
             authors_output
         )
-    elif len(stage_ids) > 0:
+    elif len(stages) > 0:
         proposals = get_proposals(
             stages,
             fund,


### PR DESCRIPTION
Hey @coire1, I ran into this issue when trying to run the importer. The variable `stage_ids` was not defined so I assumed it was the `stages` from the CLI args.